### PR TITLE
Drag image zoom

### DIFF
--- a/vegbilder-client/src/components/ImageView/ImageView.tsx
+++ b/vegbilder-client/src/components/ImageView/ImageView.tsx
@@ -35,17 +35,13 @@ interface IImageViewProps {
 }
 
 interface IScrollState {
-  clientY: number;
-  clientX: number;
-  scrollX: number;
-  scrollY: number;
+  mousePosition: { x: number; y: number };
+  scroll: { x: number; y: number };
 }
 
 type ScrollAction =
-  | { type: 'clientX'; newVal: number }
-  | { type: 'clientY'; newVal: number }
-  | { type: 'scrollY'; newVal: number }
-  | { type: 'scrollX'; newVal: number };
+  | { type: 'mousePosition'; newVal: { x: number; y: number } }
+  | { type: 'scroll'; newVal: { x: number; y: number } };
 
 const ImageView = ({ setView, showSnackbarMessage }: IImageViewProps) => {
   const classes = useStyles();
@@ -56,38 +52,25 @@ const ImageView = ({ setView, showSnackbarMessage }: IImageViewProps) => {
   const [cursor, setCursor] = useState('zoom-out');
 
   const initialScrollState = {
-    clientX: 0,
-    clientY: 0,
-    scrollX: 0,
-    scrollY: 0,
+    mousePosition: { x: 0, y: 0 },
+    scroll: { x: 0, y: 0 },
   };
 
   const scrollReducer = (state: IScrollState, action: ScrollAction) => {
     switch (action.type) {
-      case 'clientX': {
+      case 'mousePosition': {
         return {
           ...state,
-          clientX: action.newVal,
+          mousePosition: { x: action.newVal.x, y: action.newVal.y },
         };
       }
-      case 'clientY': {
+      case 'scroll': {
         return {
           ...state,
-          clientY: action.newVal,
-        };
-      }
-      case 'scrollX': {
-        return {
-          ...state,
-          scrollX: state.scrollX + action.newVal - state.clientX,
-          clientX: action.newVal,
-        };
-      }
-      case 'scrollY': {
-        return {
-          ...state,
-          scrollY: state.scrollY + action.newVal - state.clientY,
-          clientY: action.newVal,
+          x: state.scroll.x + action.newVal.x - state.mousePosition.x,
+          mousePositionX: action.newVal.x,
+          y: state.scroll.y + action.newVal.y - state.mousePosition.y,
+          mousePositionY: action.newVal.y,
         };
       }
       default:
@@ -107,8 +90,7 @@ const ImageView = ({ setView, showSnackbarMessage }: IImageViewProps) => {
 
     const onMouseDown = (event: MouseEvent) => {
       event.preventDefault();
-      dispatch({ type: 'clientX', newVal: event.clientX });
-      dispatch({ type: 'clientY', newVal: event.clientY });
+      dispatch({ type: 'mousePosition', newVal: { x: event.clientX, y: event.clientY } });
       shouldScroll = true;
       mouseMoved = false;
     };
@@ -130,12 +112,11 @@ const ImageView = ({ setView, showSnackbarMessage }: IImageViewProps) => {
         setCursor('grab');
         if (currentImageContainerRef) {
           currentImageContainerRef.scrollLeft =
-            scrollState.scrollX + event.clientX - scrollState.clientX;
+            scrollState.scroll.x + event.clientX - scrollState.mousePosition.x;
           currentImageContainerRef.scrollTop =
-            scrollState.scrollY + event.clientY - scrollState.clientY;
+            scrollState.scroll.y + event.clientY - scrollState.mousePosition.y;
         }
-        dispatch({ type: 'scrollX', newVal: event.clientX });
-        dispatch({ type: 'scrollY', newVal: event.clientY });
+        dispatch({ type: 'scroll', newVal: { x: event.clientX, y: event.clientY } });
       }
     };
 
@@ -150,7 +131,7 @@ const ImageView = ({ setView, showSnackbarMessage }: IImageViewProps) => {
       currentImageContainerRef.removeEventListener('mouseout', onMouseOut);
       currentImageContainerRef.removeEventListener('mousemove', onMouseMove);
     };
-  }, [imageContainerRef]);
+  }, []);
 
   return (
     <TogglesProvider>

--- a/vegbilder-client/src/components/ImageView/ImageView.tsx
+++ b/vegbilder-client/src/components/ImageView/ImageView.tsx
@@ -139,16 +139,16 @@ const ImageView = ({ setView, showSnackbarMessage }: IImageViewProps) => {
       }
     };
 
-    currentImageContainerRef.addEventListener('mousedown', (event) => onMouseDown(event));
-    currentImageContainerRef.addEventListener('mouseup', () => onMouseUp());
-    currentImageContainerRef.addEventListener('mouseout', () => onMouseOut());
-    currentImageContainerRef.addEventListener('mousemove', (event) => onMouseMove(event));
+    currentImageContainerRef.addEventListener('mousedown', onMouseDown);
+    currentImageContainerRef.addEventListener('mouseup', onMouseUp);
+    currentImageContainerRef.addEventListener('mouseout', onMouseOut);
+    currentImageContainerRef.addEventListener('mousemove', onMouseMove);
 
     return () => {
-      currentImageContainerRef.removeEventListener('mousedown', (event) => onMouseDown(event));
-      currentImageContainerRef.removeEventListener('mouseup', () => onMouseUp());
-      currentImageContainerRef.removeEventListener('mouseout', () => onMouseOut());
-      currentImageContainerRef.removeEventListener('mousemove', (event) => onMouseMove(event));
+      currentImageContainerRef.removeEventListener('mousedown', onMouseDown);
+      currentImageContainerRef.removeEventListener('mouseup', onMouseUp);
+      currentImageContainerRef.removeEventListener('mouseout', onMouseOut);
+      currentImageContainerRef.removeEventListener('mousemove', onMouseMove);
     };
   }, [imageContainerRef]);
 

--- a/vegbilder-client/src/components/ImageView/ImageView.tsx
+++ b/vegbilder-client/src/components/ImageView/ImageView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Grid from '@material-ui/core/Grid';
 import { makeStyles } from '@material-ui/styles';
 import { useRecoilValue } from 'recoil';
@@ -38,10 +38,45 @@ const ImageView = ({ setView, showSnackbarMessage }: IImageViewProps) => {
   const classes = useStyles();
   const isHistoryMode = useRecoilValue(isHistoryModeState);
   const [showReportErrorsScheme, setShowReportErrorsScheme] = useState(false);
+  const [isScrolling, setIsScrolling] = useState(false);
+  const [clientX, setClientX] = useState(0);
+  const [scrollX, setScrollX] = useState(0);
+
+  const ref = useRef<HTMLImageElement>(null);
+
+  const onMouseDown = (event: React.MouseEvent<Element, MouseEvent>) => {
+    event.preventDefault();
+    setClientX(event.clientX);
+    setIsScrolling(true);
+  };
+
+  const onMouseUp = () => {
+    setIsScrolling(false);
+  };
+
+  const onMouseMove = (event: React.MouseEvent<Element, MouseEvent>) => {
+    event.preventDefault();
+    if (isScrolling) {
+      if (ref.current) {
+        ref.current.scrollLeft = scrollX + event.clientX - clientX;
+        ref.current.scrollTop = 200;
+        console.log(ref.current.scrollLeft);
+      }
+      setScrollX(scrollX + event.clientX - clientX);
+      setClientX(event.clientX);
+    }
+  };
 
   return (
     <TogglesProvider>
-      <Grid item className={classes.content}>
+      <Grid
+        item
+        className={classes.content}
+        onMouseDown={(event) => onMouseDown(event)}
+        onMouseUp={() => onMouseUp}
+        onMouseMove={(event) => onMouseMove(event)}
+        ref={ref}
+      >
         {isHistoryMode ? (
           <div className={classes.imageseries}>
             {' '}

--- a/vegbilder-client/src/components/ImageView/ImageView.tsx
+++ b/vegbilder-client/src/components/ImageView/ImageView.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles(() => ({
     flex: '1 1 auto', // Allow the grid item containing the main content to grow and shrink to fill the available height.
     position: 'relative', // Needed for the small map to be positioned correctly relative to the top left corner of the content container
     height: '100%',
-    overflow: 'auto',
+    overflow: 'hidden',
     cursor: 'grab',
   },
   footer: {
@@ -67,6 +67,10 @@ const ImageView = ({ setView, showSnackbarMessage }: IImageViewProps) => {
       if (!mouseMoved) setIsEnLargedImage((prevState) => !prevState);
     };
 
+    const onMouseOut = () => {
+      shouldScroll = false;
+    };
+
     const onMouseMove = (event: MouseEvent) => {
       event.preventDefault();
       mouseMoved = true;
@@ -84,11 +88,13 @@ const ImageView = ({ setView, showSnackbarMessage }: IImageViewProps) => {
 
     currentCardRef.addEventListener('mousedown', (event) => onMouseDown(event));
     currentCardRef.addEventListener('mouseup', () => onMouseUp());
+    currentCardRef.addEventListener('mouseout', () => onMouseOut());
     currentCardRef.addEventListener('mousemove', (event) => onMouseMove(event));
 
     return () => {
       currentCardRef.removeEventListener('mousedown', (event) => onMouseDown(event));
       currentCardRef.removeEventListener('mouseup', () => onMouseUp());
+      currentCardRef.removeEventListener('mouseout', () => onMouseOut());
       currentCardRef.removeEventListener('mousemove', (event) => onMouseMove(event));
     };
   }, [containerRef]);

--- a/vegbilder-client/src/components/ImageView/ImageView.tsx
+++ b/vegbilder-client/src/components/ImageView/ImageView.tsx
@@ -111,6 +111,7 @@ const ImageView = ({ setView, showSnackbarMessage }: IImageViewProps) => {
             exitImageView={setView}
             showMessage={showSnackbarMessage}
             showCloseButton={true}
+            isEnlargedImage={isEnlargedImage}
           />
         )}
         <SmallMapContainer exitImageView={setView} />

--- a/vegbilder-client/src/components/ImageView/ImageView.tsx
+++ b/vegbilder-client/src/components/ImageView/ImageView.tsx
@@ -17,9 +17,6 @@ const useStyles = makeStyles(() => ({
     position: 'relative', // Needed for the small map to be positioned correctly relative to the top left corner of the content container
     height: '100%',
     overflow: 'hidden',
-    '&:focus': {
-      boxShadow: '5px 10px #888888',
-    },
   },
   footer: {
     flex: '0 1 4.5rem',
@@ -48,8 +45,7 @@ interface IScrollState {
 
 type ScrollAction =
   | { type: 'mousePosition'; newVal: { x: number; y: number } }
-  | { type: 'scroll'; newVal: { x: number; y: number } }
-  | { type: 'pressLeft' };
+  | { type: 'scroll'; newVal: { x: number; y: number } };
 
 const ImageView = ({ setView, showSnackbarMessage }: IImageViewProps) => {
   const classes = useStyles();
@@ -79,13 +75,6 @@ const ImageView = ({ setView, showSnackbarMessage }: IImageViewProps) => {
           mousePositionX: action.newVal.x,
           y: state.scroll.y + action.newVal.y - state.mousePosition.y,
           mousePositionY: action.newVal.y,
-        };
-      }
-      case 'pressLeft': {
-        return {
-          ...state,
-          mousePositionX: state.mousePosition.x - 10,
-          x: state.scroll.x - 10,
         };
       }
       default:

--- a/vegbilder-client/src/components/ImageView/ImageViewer/ImageViewer.tsx
+++ b/vegbilder-client/src/components/ImageView/ImageViewer/ImageViewer.tsx
@@ -39,13 +39,11 @@ const useStyles = makeStyles((theme) => ({
     maxHeight: 'calc(100vh - 9.5rem)', // Total view height minus the height of the header and footer combined
     maxWidth: '100%',
     objectFit: 'contain',
-    cursor: 'zoom-in',
   },
   enlargedImage: {
     width: 'auto',
     height: 'auto',
     position: 'absolute',
-    zIndex: 1,
   },
   canvas: {
     position: 'absolute',

--- a/vegbilder-client/src/components/ImageView/ImageViewer/ImageViewer.tsx
+++ b/vegbilder-client/src/components/ImageView/ImageViewer/ImageViewer.tsx
@@ -46,9 +46,6 @@ const useStyles = makeStyles((theme) => ({
     height: 'auto',
     position: 'absolute',
     zIndex: 1,
-    //cursor: 'zoom-out',
-    //overflow: 'auto',
-    //cursor: 'grab',
   },
   canvas: {
     position: 'absolute',
@@ -64,9 +61,15 @@ interface IImageViewerProps {
   exitImageView: () => void;
   showMessage: (message: string) => void;
   showCloseButton: boolean;
+  isEnlargedImage?: boolean;
 }
 
-const ImageViewer = ({ exitImageView, showMessage, showCloseButton }: IImageViewerProps) => {
+const ImageViewer = ({
+  exitImageView,
+  showMessage,
+  showCloseButton,
+  isEnlargedImage,
+}: IImageViewerProps) => {
   const classes = useStyles();
   const { currentImagePoint, setCurrentImagePoint } = useCurrentImagePoint();
   const { filteredImagePoints } = useFilteredImagePoints();
@@ -77,7 +80,6 @@ const ImageViewer = ({ exitImageView, showMessage, showCloseButton }: IImageView
   const timer = useRecoilValue(timerState);
   const isHistoryMode = useRecoilValue(isHistoryModeState);
   const currentHistoryImage = useRecoilValue(currentHistoryImageState);
-  const [isEnlargedImage, setIsEnlargedImage] = useState(false);
 
   const [nextImagePoint, setNextImagePoint] = useState<IImagePoint | null>(null);
   const [previousImagePoint, setPreviousImagePoint] = useState<IImagePoint | null>(null);
@@ -323,9 +325,9 @@ const ImageViewer = ({ exitImageView, showMessage, showCloseButton }: IImageView
             className={isEnlargedImage ? classes.enlargedImage : classes.image}
             ref={imgRef}
             onLoad={onImageLoaded}
-            onClick={() => {
-              if (!isHistoryMode) setIsEnlargedImage(!isEnlargedImage);
-            }}
+            // onClick={() => {
+            //   if (!isHistoryMode) setIsEnlargedImage(!isEnlargedImage);
+            // }}
           />
           {renderMeterLine()}
         </>

--- a/vegbilder-client/src/components/ImageView/ImageViewer/ImageViewer.tsx
+++ b/vegbilder-client/src/components/ImageView/ImageViewer/ImageViewer.tsx
@@ -42,12 +42,12 @@ const useStyles = makeStyles((theme) => ({
     cursor: 'zoom-in',
   },
   enlargedImage: {
-    position: 'absolute',
-    zIndex: 1,
     width: 'auto',
     height: 'auto',
+    position: 'absolute',
+    zIndex: 1,
     overflow: 'auto',
-    cursor: 'zoom-out',
+    cursor: 'grab',
   },
   canvas: {
     position: 'absolute',
@@ -56,6 +56,7 @@ const useStyles = makeStyles((theme) => ({
     maxWidth: '100%',
     maxHeight: '100%',
   },
+  enlargedImageContainer: {},
 }));
 
 interface IImageViewerProps {

--- a/vegbilder-client/src/components/ImageView/ImageViewer/ImageViewer.tsx
+++ b/vegbilder-client/src/components/ImageView/ImageViewer/ImageViewer.tsx
@@ -61,14 +61,14 @@ interface IImageViewerProps {
   exitImageView: () => void;
   showMessage: (message: string) => void;
   showCloseButton: boolean;
-  isEnlargedImage?: boolean;
+  isZoomedInImage?: boolean;
 }
 
 const ImageViewer = ({
   exitImageView,
   showMessage,
   showCloseButton,
-  isEnlargedImage,
+  isZoomedInImage,
 }: IImageViewerProps) => {
   const classes = useStyles();
   const { currentImagePoint, setCurrentImagePoint } = useCurrentImagePoint();
@@ -322,12 +322,9 @@ const ImageViewer = ({
                 : getImageUrl(currentImagePoint)
             }
             alt="vegbilde"
-            className={isEnlargedImage ? classes.enlargedImage : classes.image}
+            className={isZoomedInImage ? classes.enlargedImage : classes.image}
             ref={imgRef}
             onLoad={onImageLoaded}
-            // onClick={() => {
-            //   if (!isHistoryMode) setIsEnlargedImage(!isEnlargedImage);
-            // }}
           />
           {renderMeterLine()}
         </>

--- a/vegbilder-client/src/components/ImageView/ImageViewer/ImageViewer.tsx
+++ b/vegbilder-client/src/components/ImageView/ImageViewer/ImageViewer.tsx
@@ -46,8 +46,9 @@ const useStyles = makeStyles((theme) => ({
     height: 'auto',
     position: 'absolute',
     zIndex: 1,
-    overflow: 'auto',
-    cursor: 'grab',
+    //cursor: 'zoom-out',
+    //overflow: 'auto',
+    //cursor: 'grab',
   },
   canvas: {
     position: 'absolute',

--- a/vegbilder-client/src/components/MapContainer/SmallMapContainer.tsx
+++ b/vegbilder-client/src/components/MapContainer/SmallMapContainer.tsx
@@ -14,10 +14,10 @@ import { EnlargeIcon } from 'components/Icons/Icons';
 const useStyles = makeStyles((theme) => ({
   minimap: {
     position: 'absolute',
-    width: '300px',
-    height: '300px',
-    left: '20px',
-    top: '20px',
+    width: '20vw',
+    height: '20vw',
+    left: '1.25rem',
+    top: '1.25rem',
     border: `1px ${theme.palette.primary.main} solid`,
     boxShadow: '1px 2px 2px 2px rgba(0, 0, 0, 0.4)',
   },
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme) => ({
   enlargeButton: {
     position: 'absolute',
     zIndex: 1000,
-    top: 2,
+    bottom: 2,
     right: 2,
   },
 }));

--- a/vegbilder-client/src/utilities/imagePointUtilities.ts
+++ b/vegbilder-client/src/utilities/imagePointUtilities.ts
@@ -4,7 +4,7 @@ import { getBearingBetween, getDistanceInMetersBetween } from './latlngUtilities
 import { splitDateTimeString } from './dateTimeUtilities';
 import { IImagePoint, ILatlng } from 'types';
 import { Dictionary } from 'lodash';
-//import { rewriteUrlDomainToLocalhost } from 'local-dev/rewriteurl';
+import { rewriteUrlDomainToLocalhost } from 'local-dev/rewriteurl';
 
 const getImagePointLatLng = (imagePoint: IImagePoint) => {
   if (imagePoint) {
@@ -14,7 +14,8 @@ const getImagePointLatLng = (imagePoint: IImagePoint) => {
   }
 };
 
-const getImageUrl = (imagepoint: IImagePoint) => imagepoint.properties.URL;
+const getImageUrl = (imagepoint: IImagePoint) =>
+  rewriteUrlDomainToLocalhost(imagepoint.properties.URL);
 
 const findNearestImagePoint = (imagePoints: IImagePoint[], latlng: ILatlng) => {
   let maxDistance = 50; // meters


### PR DESCRIPTION
Når man klikker på bildet blir det i sin orginale størrelse. Da kan brukeren dra rundt i bildet (grab to scroll). Et klikk ut igjen gjør at man kommer tilbake til det reduserte bildet. 

Før klikk: 
![Screen Shot 2021-02-22 at 1 54 34 PM](https://user-images.githubusercontent.com/25438619/108711448-abadf700-7515-11eb-8223-c7566350c1eb.png)

Brukeren ser "zoom-in" cursor. Brukeren klikker på bildet og da ser det slik ut:

Etter klikk: 
![Screen Shot 2021-02-22 at 1 55 01 PM](https://user-images.githubusercontent.com/25438619/108711399-9cc74480-7515-11eb-921b-21be6a90d14d.png)

Når brukeren starter å dra i bildet får den cursor "grab". Ellers er det cursor "zoom-out". Default scrollbarer er også fjernet (etter kundens ønske) 
