### PR TITLE
Search with vegssysref issues

### DIFF
--- a/vegbilder-client/src/components/App.tsx
+++ b/vegbilder-client/src/components/App.tsx
@@ -14,6 +14,7 @@ import {
   latLngZoomQueryParameterState,
   viewQueryParamterState,
   yearQueryParameterState,
+  vegsystemreferanseState
 } from 'recoil/selectors';
 import useFetchNearestImagePoint from 'hooks/useFetchNearestImagePoint';
 import { DEFAULT_COORDINATES, DEFAULT_VIEW, DEFAULT_ZOOM } from 'constants/defaultParamters';
@@ -22,6 +23,7 @@ import { useIsMobile } from 'hooks/useIsMobile';
 import MobileLandingPage from './MobileLandingPage/MobileLandingPage';
 import getVegByVegsystemreferanse from 'apis/NVDB/getVegByVegsystemreferanse';
 import { getCoordinatesFromWkt } from 'utilities/latlngUtilities';
+import { matchAndPadVegsystemreferanse } from 'utilities/vegsystemreferanseUtilities';
 import { IImagePoint } from 'types';
 import useAsyncError from 'hooks/useAsyncError';
 
@@ -79,6 +81,7 @@ const App = () => {
   const [currentCoordinates, setCurrentCoordinates] = useRecoilState(latLngZoomQueryParameterState);
   const [, setCurrentYear] = useRecoilState(yearQueryParameterState);
   const [, setCurrentView] = useRecoilState(viewQueryParamterState);
+  const [, setCurrentVegsystemreferanseState] = useRecoilState(vegsystemreferanseState);
 
   const searchParams = new URLSearchParams(window.location.search);
   const [snackbarVisible, setSnackbarVisible] = useState(false);
@@ -160,7 +163,13 @@ const App = () => {
     const vegsystemreferanseQuery = searchParams.get('vegsystemreferanse');
 
     if (vegsystemreferanseQuery) {
-      openAppByVegsystemreferanse(vegsystemreferanseQuery, yearQuery);
+      const validVegsystemReferanse = matchAndPadVegsystemreferanse(vegsystemreferanseQuery);
+      if (validVegsystemReferanse) {
+        openAppByVegsystemreferanse(vegsystemreferanseQuery, yearQuery);
+      } else {
+        showSnackbarMessage(`Fant ingen treff på vegsystemreferanse "${vegsystemreferanseQuery}". Prøv igjen i søkefeltet.`);
+      }
+      setCurrentVegsystemreferanseState(null);
     }
 
     if (!isDefaultCoordinates(latQuery, lngQuery) && !imageIdQuery) {

--- a/vegbilder-client/src/components/App.tsx
+++ b/vegbilder-client/src/components/App.tsx
@@ -165,7 +165,7 @@ const App = () => {
     if (vegsystemreferanseQuery) {
       const validVegsystemReferanse = matchAndPadVegsystemreferanse(vegsystemreferanseQuery);
       if (validVegsystemReferanse) {
-        openAppByVegsystemreferanse(vegsystemreferanseQuery, yearQuery);
+        openAppByVegsystemreferanse(validVegsystemReferanse, yearQuery);
       } else {
         showSnackbarMessage(`Fant ingen treff på vegsystemreferanse "${vegsystemreferanseQuery}". Prøv igjen i søkefeltet.`);
       }

--- a/vegbilder-client/src/components/App.tsx
+++ b/vegbilder-client/src/components/App.tsx
@@ -135,7 +135,7 @@ const App = () => {
         const latlng = getCoordinatesFromWkt(wkt);
 
         if (latlng) {
-          if (year) {
+          if (year !== 'latest' && year !== null) {
             fetchNearestImagePointToYearAndCoordinates(latlng, parseInt(year)).then(
               (imagePoint: IImagePoint | undefined) => {
                 if (!imagePoint) {
@@ -163,11 +163,10 @@ const App = () => {
       openAppByVegsystemreferanse(vegsystemreferanseQuery, yearQuery);
     }
 
-    // if a user opens the app with only coordinates we find the nearest image from the newest year (or preset year)
     if (!isDefaultCoordinates(latQuery, lngQuery) && !imageIdQuery) {
       const latlng = { lat: currentCoordinates.lat, lng: currentCoordinates.lng };
       setCurrentCoordinates({ ...latlng, zoom: 15 });
-      if (yearQuery === 'Nyeste' || !yearQuery) {
+      if (yearQuery === 'latest' || !yearQuery) {
         fetchNearestLatestImagePoint(currentCoordinates);
       } else {
         setCommand(commandTypes.selectNearestImagePointToCurrentCoordinates);

--- a/vegbilder-client/src/components/Header/Header.tsx
+++ b/vegbilder-client/src/components/Header/Header.tsx
@@ -8,7 +8,7 @@ import Search from './Search/Search';
 import YearSelector from './YearSelector/YearSelector';
 import { CircledHelpIcon } from 'components/Icons/Icons';
 import { DEFAULT_COORDINATES, DEFAULT_ZOOM } from 'constants/defaultParamters';
-import { imagePointQueryParameterState, latLngZoomQueryParameterState } from 'recoil/selectors';
+import { imagePointQueryParameterState, latLngZoomQueryParameterState, vegsystemreferanseState } from 'recoil/selectors';
 
 const useStyles = makeStyles({
   headerToolBar: {
@@ -52,9 +52,11 @@ const Header = ({ showMessage, setMapView, showInformation, setShowInformation }
   const classes = useStyles();
   const [, setCurrentCoordinates] = useRecoilState(latLngZoomQueryParameterState);
   const [, setCurrentImagePoint] = useRecoilState(imagePointQueryParameterState);
+  const [, setCurrentVegsystemreferanse] = useRecoilState(vegsystemreferanseState);
 
   const resetToDefaultStates = () => {
     setCurrentImagePoint(null);
+    setCurrentVegsystemreferanse(null);
     setMapView();
     setCurrentCoordinates({ ...DEFAULT_COORDINATES, zoom: DEFAULT_ZOOM });
   };

--- a/vegbilder-client/src/components/Header/Search/Search.tsx
+++ b/vegbilder-client/src/components/Header/Search/Search.tsx
@@ -18,6 +18,7 @@ import {
 } from 'recoil/selectors';
 import useAsyncError from 'hooks/useAsyncError';
 import useFetchNearestImagePoint from 'hooks/useFetchNearestImagePoint';
+import useFetchNearestLatestImagePoint from 'hooks/useFetchNearestLatestImagepoint';
 import { currentYearState } from 'recoil/atoms';
 import { getImagePointLatLng } from 'utilities/imagePointUtilities';
 import { getCoordinatesFromWkt } from 'utilities/latlngUtilities';
@@ -118,6 +119,12 @@ const Search = ({ showMessage, setMapView }: ISearchProps) => {
     'Fant ingen bilder i nærheten av stedet du søkte på.'
   );
 
+  const fetchNearestLatestImagePoint = useFetchNearestLatestImagePoint(
+    showMessage,
+    'Fant ingen bilder i nærheten'
+  );
+
+
   const delayedStedsnavnQuery = useMemo(
     () =>
       debounce(async (trimmedSearch) => {
@@ -178,7 +185,7 @@ const Search = ({ showMessage, setMapView }: ISearchProps) => {
     if (latlng && latlng.lat && latlng.lng) {
       setCurrentCoordinates({ ...latlng, zoom: zoom });
       setResetImagePoint(true);
-      if (typeof currentYear === 'number')
+      if (typeof currentYear === 'number') {
         fetchNearestImagePoint(latlng, currentYear).then((imagePoint) => {
           if (imagePoint) {
             const imagePointLatLng = getImagePointLatLng(imagePoint);
@@ -186,7 +193,14 @@ const Search = ({ showMessage, setMapView }: ISearchProps) => {
           } else {
             setMapView();
           }
-        });
+        })
+      } else {
+        fetchNearestLatestImagePoint(latlng).then((imagePoint) => {
+          if (!imagePoint) {
+            setMapView();
+          };
+        })
+      };
       setSearchString('');
     }
   };

--- a/vegbilder-client/src/components/MapView/Map/ImagePointMapLayers/ImagePointMapLayers.tsx
+++ b/vegbilder-client/src/components/MapView/Map/ImagePointMapLayers/ImagePointMapLayers.tsx
@@ -24,6 +24,7 @@ const ImagePointMapLayers = () => {
     } else {
       return (
         <WMSTileLayer
+          key={oversiktsKartlag}
           url={OGC_URL}
           attribution="<a href='https://www.vegvesen.no/'>Statens vegvesen</a>"
           layers={oversiktsKartlag}

--- a/vegbilder-client/src/recoil/atoms.ts
+++ b/vegbilder-client/src/recoil/atoms.ts
@@ -14,6 +14,11 @@ export const currentYearState = atom<string | number>({
   default: parseInt(searchParams.get('year')!) || 'Nyeste',
 });
 
+export const currentVegsystemreferanseState = atom<string | null>({
+  key: 'currentVegsystemreferanse',
+  default: null
+})
+
 export const currentImagePointState = atom<IImagePoint | null>({
   key: 'currentImagePoint',
   default: null,

--- a/vegbilder-client/src/recoil/selectors.ts
+++ b/vegbilder-client/src/recoil/selectors.ts
@@ -15,6 +15,7 @@ import {
   filteredImagePointsState,
   loadedImagePointsState,
   playVideoState,
+  currentVegsystemreferanseState
 } from './atoms';
 
 export const availableYearsQuery = selector({
@@ -45,6 +46,22 @@ export const availableYearsQuery = selector({
   },
 });
 
+export const vegsystemreferanseState = selector({
+  key: 'vegsystemreferanseState',
+  get: ({ get }) => {
+    return get(currentVegsystemreferanseState);
+  },
+  set: ({ get, set }, newVegsystemreferanse) => {
+    if (get(currentVegsystemreferanseState) !== newVegsystemreferanse && typeof newVegsystemreferanse === 'string') {
+      setNewQueryParamter('vegsystemreferanse', newVegsystemreferanse);
+      set(currentVegsystemreferanseState, newVegsystemreferanse);
+    } else if (newVegsystemreferanse === null) {
+      setNewQueryParamter('vegsystemreferanse', null);
+      set(currentVegsystemreferanseState, newVegsystemreferanse);
+    }
+  }
+})
+
 export const yearQueryParameterState = selector({
   key: 'yearQueryParamterState',
   get: ({ get }) => {
@@ -68,7 +85,7 @@ export const imagePointQueryParameterState = selector({
   },
   set: ({ get, set }, newImagePoint: IImagePoint | null | DefaultValue) => {
     if (!(newImagePoint instanceof DefaultValue)) {
-      const imagePointId = newImagePoint ? newImagePoint.id : '';
+      const imagePointId = newImagePoint ? newImagePoint.id : null;
       const isVideoPlaying = get(playVideoState);
       setNewQueryParamter('imageId', imagePointId, isVideoPlaying);
       if (newImagePoint) {
@@ -154,12 +171,17 @@ export const loadedImagePointsFilterState = selector({
 });
 
 // utilities
-const setNewQueryParamter = (name: queryParamterNames, value: string, isVideoPlaying = false) => {
+const setNewQueryParamter = (name: queryParamterNames, value: string | null, isVideoPlaying = false) => {
   const newSearchParams = new URLSearchParams(window.location.search);
-  newSearchParams.set(name, value);
-  if (isVideoPlaying) {
-    delayedReplaceHistory(newSearchParams);
+  if (value !== null) {
+    newSearchParams.set(name, value);
+    if (isVideoPlaying) {
+      delayedReplaceHistory(newSearchParams);
+    } else {
+      window.history.replaceState(null, '', '?' + newSearchParams.toString());
+    }
   } else {
+    newSearchParams.delete(name);
     window.history.replaceState(null, '', '?' + newSearchParams.toString());
   }
 };

--- a/vegbilder-client/src/types.ts
+++ b/vegbilder-client/src/types.ts
@@ -52,6 +52,6 @@ export interface ILoadedImagePoints {
   availableDates?: string[];
 }
 
-export type queryParamterNames = 'imageId' | 'year' | 'view' | 'lat' | 'lng' | 'zoom';
+export type queryParamterNames = 'imageId' | 'year' | 'view' | 'lat' | 'lng' | 'zoom' | 'vegsystemreferanse';
 
 export type viewTypes = 'map' | 'image';


### PR DESCRIPTION
3 bugs funnet i deploy.

1: Vegsystemreferansen endres ikke når man velger andre bilder, dette er litt misvisende. enten bør den vel oppdateres eller fjernes etter man har kommet inn i kartet?

2: Trykker man på svv logo zoomes det ut, men her henger også vegsystemreferansen igjen

3: Kan ikke velge nyeste kartlaget, når man har zoomet ut